### PR TITLE
Impl: ignore_missing option on get_flag, v0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pypandoc import convert_file
 
 setup(
     name="ncflag",
-    version="0.3.0",
+    version="0.3.1",
     description="Utility and library to interface with CF-Compliant NetCDF flag variables.",
     author="Stefan Codrescu",
     author_email="stefan.codrescu@noaa.gov",

--- a/test/test_misc_api.py
+++ b/test/test_misc_api.py
@@ -4,19 +4,24 @@ import numpy as np
 
 
 class TestApi(TestCase):
+    def setUp(self):
+        self.flags = np.array([0, 0, 1, 2, 3], dtype=np.ubyte)
+        self.flag_meanings = "good medium bad extra_bad"
+        self.flag_values = np.array([0, 1, 2, 3])
+        self.f = FlagWrap(self.flags, self.flag_meanings, self.flag_values)
 
     def test_valid_meaning(self):
-        flags = np.array([0, 0, 1, 2, 3], dtype=np.ubyte)
-        flag_meanings = "good medium bad extra_bad"
-        flag_values = np.array([0, 1, 2, 3])
-        f = FlagWrap(flags, flag_meanings, flag_values)
-
-        for flag_meaning in flag_meanings.split():
-            self.assertTrue(f.is_valid_meaning(flag_meaning))
+        for flag_meaning in self.flag_meanings.split():
+            self.assertTrue(self.f.is_valid_meaning(flag_meaning))
 
         for not_a_meaning in ["test", "not", "valid", "good1", "extra"]:
-            self.assertFalse(f.is_valid_meaning(not_a_meaning))
-        
+            self.assertFalse(self.f.is_valid_meaning(not_a_meaning))
 
+    def test_get_flag_on_missing_meaning(self):
+        for not_a_meaning in ["test", "not", "valid", "good1", "extra"]:
+            flags = self.f.get_flag(not_a_meaning, ignore_missing=True)
+            self.assertEqual(np.count_nonzero(flags), 0)
 
-
+            with self.assertRaises(ValueError):
+                # check backwards compat: missing meaning raises
+                self.f.get_flag(not_a_meaning, ignore_missing=False)

--- a/test/test_reduce.py
+++ b/test/test_reduce.py
@@ -6,12 +6,7 @@ from ncflag import FlagWrap
 class TestReduce(TestCase):
     def test_reduce_axis0(self):
 
-        flags = np.array([
-            [0, 1],
-            [1, 0],
-            [0, 0],
-            [1, 1]
-        ], dtype=np.ubyte)
+        flags = np.array([[0, 1], [1, 0], [0, 0], [1, 1]], dtype=np.ubyte)
 
         f = FlagWrap(flags, "good bad", [0, 1])
 
@@ -19,15 +14,9 @@ class TestReduce(TestCase):
         np.testing.assert_array_equal(f_reduced.get_flag("good"), [0, 0])
         np.testing.assert_array_equal(f_reduced.get_flag("bad"), [1, 1])
 
-
     def test_reduce_axis1(self):
 
-        flags = np.array([
-            [0, 1],
-            [1, 0],
-            [0, 0],
-            [1, 1]
-        ], dtype=np.ubyte)
+        flags = np.array([[0, 1], [1, 0], [0, 0], [1, 1]], dtype=np.ubyte)
 
         f = FlagWrap(flags, "good bad", [0, 1])
 
@@ -37,12 +26,15 @@ class TestReduce(TestCase):
 
     def test_reduce_mask(self):
 
-        flags = np.array([
-            [3, 1],  # red + green, red
-            [0, 4],  # ---, blue
-            [4, 3],  # blue, red + green
-            [2, 1]   # green, red
-        ], dtype=np.ubyte)
+        flags = np.array(
+            [
+                [3, 1],  # red + green, red
+                [0, 4],  # ---, blue
+                [4, 3],  # blue, red + green
+                [2, 1],  # green, red
+            ],
+            dtype=np.ubyte,
+        )
 
         f = FlagWrap(flags, "red green blue", [1, 2, 4], [1, 2, 4])
 
@@ -51,11 +43,8 @@ class TestReduce(TestCase):
         f_reduced = f.reduce(axis=1, exclude_mask=1)
 
         # there should be no red, since we masked it
-        np.testing.assert_array_equal(f_reduced.get_flag("red"), [0, 0, 0, 0]) 
+        np.testing.assert_array_equal(f_reduced.get_flag("red"), [0, 0, 0, 0])
 
         # make sure green and blue got through, when they weren't mixed with red
         np.testing.assert_array_equal(f_reduced.get_flag("green"), [0, 0, 0, 1])
         np.testing.assert_array_equal(f_reduced.get_flag("blue"), [0, 1, 1, 0])
-
-        
-

--- a/test/test_theoretical.py
+++ b/test/test_theoretical.py
@@ -14,8 +14,8 @@ class TestTheoretical(TestCase):
             FlagWrap(np.array([]), "flag1 flag2", [1, 2], [-1, -1, -1])
 
     def test_exclusive_flag_type(self):
-        """ A barrage of tests to make sure everything works properly for flag variables defined
-         so that every flag_meaning is mutually exclusive. """
+        """A barrage of tests to make sure everything works properly for flag variables defined
+        so that every flag_meaning is mutually exclusive."""
 
         original_flags = np.array([0, 0, 1, 2, 3, -1], dtype=np.ubyte)
 
@@ -122,9 +122,9 @@ class TestTheoretical(TestCase):
         # ok, we'll call it good there.
 
     def test_maskedarray_initial_flags(self):
-        """ Similar to the previous test, except start with a masked array and fill...
+        """Similar to the previous test, except start with a masked array and fill...
         This will be what it looks like if someone does init_from_netcdf for an unwritten variable
-        that actually has shape. """
+        that actually has shape."""
 
         original_flags = np.ma.zeros(5, dtype=np.ubyte)
         original_flags.mask = True


### PR DESCRIPTION
Request from @A-Mahon:

> Add a method to ncflag that combines the functionality of find_flag and get_flag, flattening the arrays as in get_flag, but not raising an exception if any of the flags are not present.

This is a great suggestion for dealing with the euvs flagging change you're working on. I implemented by adding an `ignore_missing` optional bool argument to `get_flag`. The default value is False for backwards compatibility.