### PR TITLE
v0.3.3: compat with numpy 1.24+ oob int cast rules

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -9,28 +9,31 @@ jobs:
     strategy:
         matrix:
             os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-            python-version: [3.7, 3.8, 3.9]
+            python-version: [3.11, 3.12]
     steps:
-      - uses: actions/checkout@v2
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/checkout@v4
+      - uses: mamba-org/setup-micromamba@v1
         with:
-          activate-environment: ncflag
+          micromamba-version: '2.0.8-0' # from https://github.com/mamba-org/micromamba-releases
           environment-file: environment.yml
-          python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
-      - name: Info
+          cache-environment: true
+          post-cleanup: 'none'
+          create-args: >-
+            python=${{ matrix.python-version }}
+            black=24.10.0
+            mypy=1.11.2
+            isort=5.13.2 
+            ruff=0.6.9
+      - name: black
         shell: bash -l {0}
-        run: |
-          conda info
-          conda list
-      - name: Lint
+        run: "python -m black --check ."
+      - name: isort
         shell: bash -l {0}
-        run: |
-            conda install flake8
-            python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-            python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Run unit tests
+        run: "python -m isort -c -v ."
+      - name: ruff
         shell: bash -l {0}
-        run: |
-            python -m unittest discover
+        run: "python -m ruff check"
+      - name: test
+        shell: bash -l {0}
+        run: "python -m unittest discover"
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
         matrix:
-            os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
             python-version: [3.11, 3.12]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.3.3 - 2024 04 08
+
+- Bug fix: compatibility with numpy 1.24+ new out-of-bounds int conversion failure 
+  https://numpy.org/devdocs/release/1.24.0-notes.html#conversion-of-out-of-bound-python-integers
+
 # v0.3.2 - 2022 10 02
 
 - use long_description_content_type="text/markdown" in setup.py

--- a/ncflag/__init__.py
+++ b/ncflag/__init__.py
@@ -1,1 +1,1 @@
-from .flag_wrapper import FlagWrap
+from .flag_wrapper import FlagWrap as FlagWrap

--- a/ncflag/cli.py
+++ b/ncflag/cli.py
@@ -1,7 +1,9 @@
-import click
 import logging
-import pkg_resources
+
+import click
 import netCDF4 as nc
+import pkg_resources
+
 from .flag_wrapper import FlagWrap
 
 try:
@@ -45,8 +47,8 @@ def show_flags(ctx, param, ncfile):
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
     default="WARNING",
 )
-def cli(ncfile, flag, use_time_var, l):
-    logging.getLogger().setLevel(l)
+def cli(ncfile, flag, use_time_var, log_level):
+    logging.getLogger().setLevel(log_level)
     with nc.Dataset(ncfile) as nc_in:  # type: nc.Dataset
         # initial checks
         v = nc_in.variables[flag]  # type: nc.Variable

--- a/ncflag/flag_wrapper.py
+++ b/ncflag/flag_wrapper.py
@@ -47,7 +47,7 @@ class FlagWrap(object):
         )
 
         if flag_masks is None:
-            self._flag_masks = np.full_like(self._flag_values, -1)
+            self._flag_masks = np.invert(np.zeros_like(self.flag_values))
         else:
             self._flag_masks = np.array(flag_masks).astype(self.flags.dtype)
             assert len(self._flag_masks) == len(
@@ -121,7 +121,7 @@ class FlagWrap(object):
         nc_var.flag_meanings = " ".join(self.flag_meanings)
         nc_var.flag_values = self._flag_values
         if (
-            not np.all(self._flag_masks == np.full_like(self._flag_values, -1))
+            not np.all(self._flag_masks == np.invert(np.zeros_like(self.flag_values)))
             or getattr(nc_var, "flag_masks", None) is not None
         ):
             # only write masks if they aren't the default all bits 1 or somethign existed before

--- a/ncflag/flag_wrapper.py
+++ b/ncflag/flag_wrapper.py
@@ -47,7 +47,7 @@ class FlagWrap(object):
         )
 
         if flag_masks is None:
-            self._flag_masks = np.invert(np.zeros_like(self.flag_values))
+            self._flag_masks = np.invert(np.zeros_like(self._flag_values))
         else:
             self._flag_masks = np.array(flag_masks).astype(self.flags.dtype)
             assert len(self._flag_masks) == len(
@@ -121,7 +121,7 @@ class FlagWrap(object):
         nc_var.flag_meanings = " ".join(self.flag_meanings)
         nc_var.flag_values = self._flag_values
         if (
-            not np.all(self._flag_masks == np.invert(np.zeros_like(self.flag_values)))
+            not np.all(self._flag_masks == np.invert(np.zeros_like(self._flag_values)))
             or getattr(nc_var, "flag_masks", None) is not None
         ):
             # only write masks if they aren't the default all bits 1 or somethign existed before

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="ncflag",
-    version="0.3.2",
+    version="0.3.3",
     description="Utility and library to interface with CF-Compliant NetCDF flag variables.",
     author="Stefan Codrescu",
     author_email="stefan.codrescu@noaa.gov",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 setup(
     name="ncflag",
     version="0.3.3",

--- a/test/test_misc_api.py
+++ b/test/test_misc_api.py
@@ -1,6 +1,8 @@
-from ncflag import FlagWrap
 from unittest import TestCase
+
 import numpy as np
+
+from ncflag import FlagWrap
 
 
 class TestApi(TestCase):

--- a/test/test_real_netcdf.py
+++ b/test/test_real_netcdf.py
@@ -1,8 +1,10 @@
-from ncflag import FlagWrap
-from unittest import TestCase
-import numpy as np
-import netCDF4 as nc
 import os
+from unittest import TestCase
+
+import netCDF4 as nc
+import numpy as np
+
+from ncflag import FlagWrap
 
 
 def get_dataset():

--- a/test/test_reduce.py
+++ b/test/test_reduce.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
+
 import numpy as np
+
 from ncflag import FlagWrap
 
 

--- a/test/test_theoretical.py
+++ b/test/test_theoretical.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
+
 import numpy as np
+
 from ncflag import FlagWrap
 
 

--- a/test/test_theoretical.py
+++ b/test/test_theoretical.py
@@ -19,7 +19,7 @@ class TestTheoretical(TestCase):
         """A barrage of tests to make sure everything works properly for flag variables defined
         so that every flag_meaning is mutually exclusive."""
 
-        original_flags = np.array([0, 0, 1, 2, 3, -1], dtype=np.ubyte)
+        original_flags = np.array([0, 0, 1, 2, 3, 255], dtype=np.ubyte)
 
         f = FlagWrap(
             original_flags.copy(), "good medium bad extra_bad", np.array([0, 1, 2, 3])


### PR DESCRIPTION
## Summary

Numpy 1.24+ changed out-of-bounds int overflow handling to fail instead of succeed silently. `ncflag` used the `np.uint8(-1) == np.iinfo(np.uint8).max` trick to handle unmasked flags on the same code path as masked flags. The oob cast now fails at some point on numpy 2.0+.

Changed to use `np.invert(np.zeros_like(x))` instead.

Ref: https://numpy.org/devdocs/release/1.24.0-notes.html#conversion-of-out-of-bound-python-integers